### PR TITLE
feat: add services and controllers to manage Song entity

### DIFF
--- a/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/domain/songs/CreateSongInput.java
+++ b/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/domain/songs/CreateSongInput.java
@@ -1,0 +1,143 @@
+package io.davorpatech.apps.musicalsurveyor.domain.songs;
+
+import io.davorpatech.fwk.model.BaseValueObject;
+import io.davorpatech.fwk.model.commands.CreateInputCmd;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.io.Serial;
+import java.util.Objects;
+
+/**
+ * Input object for creating a new {@code Song}.
+ *
+ * <p>Domain DTOs are immutable objects. As a DTO, it is a simple
+ * POJO that holds data and has no behavior. It is used to transfer
+ * data between the presentation layer and the services layer. It is
+ * also used to validate the data sent to the services layer. It is a
+ * good practice to use different DTOs for each one of service operations.
+ * This way, the DTOs can be extended in the future without breaking the
+ * service contract.
+ *
+ * <p>This is why the {@link CreateSongInput} and the {@link UpdateSongInput}
+ * are different classes. They both represent the same data, but the
+ * {@link UpdateSongInput} has an additional {@code id} field. This is
+ * because the {@code id} is required to update an existing {@code Song}.
+ * The {@code id} is not required to create a new {@code Song} because
+ * the server will generate a new {@code id} for the new {@code Song}.
+ *
+ * <p>As a domain DTO, it follows the {@link BaseValueObject} contract,
+ * which means that it identifiable field is fuzzy, and it can be compared
+ * for equality to other domain DTOs using all of its fields.
+ */
+public class CreateSongInput extends BaseValueObject implements CreateInputCmd // NOSONAR
+{
+    @Serial
+    private static final long serialVersionUID = 9210628566079600699L;
+
+    @NotNull
+    private final Long artistId;
+
+    @NotBlank
+    @Size(max = SongConstants.TITLE_MAXLEN)
+    private final String title;
+
+    @Min(SongConstants.RELEASE_YEAR_MIN)
+    private final Integer releaseYear;
+
+    @Min(SongConstants.DURATION_MIN)
+    private final Integer duration;
+
+    @Size(max = SongConstants.GENRE_MAXLEN)
+    private final String genre;
+
+    /**
+     * Constructs a new {@link CreateSongInput} with the given arguments.
+     *
+     * @param artistId    the artist ID owning the song
+     * @param title       the song title
+     * @param releaseYear the song release year
+     * @param duration    the song duration in seconds
+     * @param genre       the musical genre of the song
+     */
+    public CreateSongInput(Long artistId, String title, Integer releaseYear, Integer duration, String genre) {
+        super();
+        this.artistId = artistId;
+        this.title = title;
+        this.releaseYear = releaseYear;
+        this.duration = duration;
+        this.genre = genre;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CreateSongInput other = (CreateSongInput) o;
+        return Objects.equals(artistId, other.artistId) &&
+            Objects.equals(title, other.title) &&
+            Objects.equals(releaseYear, other.releaseYear) &&
+            Objects.equals(duration, other.duration) &&
+            Objects.equals(genre, other.genre);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(artistId, title, releaseYear, duration, genre);
+    }
+
+    @Override
+    protected String defineObjAttrs() {
+        return String.format(
+            "artistId=%s, title='%s', releaseYear=%s, duration=%s, genre=%s",
+            artistId, title, releaseYear, duration,
+            genre == null ? null : '\'' + genre + '\'');
+    }
+
+    /**
+     * Returns the artist ID owning the song.
+     *
+     * @return the artist ID
+     */
+    public Long getArtistId() {
+        return artistId;
+    }
+
+    /**
+     * Returns the song title.
+     *
+     * @return the song title
+     */
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * Returns the song release year.
+     *
+     * @return the song release year
+     */
+    public Integer getReleaseYear() {
+        return releaseYear;
+    }
+
+    /**
+     * Returns the song duration in seconds.
+     *
+     * @return the song duration in seconds
+     */
+    public Integer getDuration() {
+        return duration;
+    }
+
+    /**
+     * Returns the musical genre of the song.
+     *
+     * @return the musical genre of the song
+     */
+    public String getGenre() {
+        return genre;
+    }
+}

--- a/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/domain/songs/FindSongsInput.java
+++ b/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/domain/songs/FindSongsInput.java
@@ -1,0 +1,75 @@
+package io.davorpatech.apps.musicalsurveyor.domain.songs;
+
+import io.davorpatech.fwk.model.BaseValueObject;
+import io.davorpatech.fwk.model.commands.BaseSortableFindInputCmd;
+import org.springframework.data.domain.Sort;
+import org.springframework.lang.Nullable;
+
+import java.io.Serial;
+
+/**
+ * Input object for finding {@code Song} instances.
+ *
+ * <p>Optionally, it can be used to find {@code Song} instances by artist ID.
+ *
+ * <p>As a domain DTO, it follows the {@link BaseValueObject} contract,
+ * which means that it identifiable field is fuzzy, and it can be compared
+ * for equality to other domain DTOs using all of its fields.
+ */
+public class FindSongsInput extends BaseSortableFindInputCmd // NOSONAR
+{
+    @Serial
+    private static final long serialVersionUID = -5876522385896575289L;
+
+    private final Long artistId;
+
+    /**
+     * Constructs a new {@link FindSongsInput} with the given arguments.
+     *
+     * @param pageNumber the number of the current page (zero-index based)
+     * @param pageSize   the page size; thus is, the number of items to be returned
+     * @param sort       the sort to be used as part of any search query
+     * @param artistId   the artist ID to be used as part of any search query
+     */
+    FindSongsInput(int pageNumber, int pageSize, @Nullable Sort sort,
+                   @Nullable Long artistId) {
+        super(pageNumber, pageSize, sort);
+        this.artistId = artistId;
+    }
+
+    /**
+     * Returns the artist ID to be used as part of any search query.
+     *
+     * @return the artist ID to be used as part of any search query
+     */
+    public Long getArtistId() {
+        return artistId;
+    }
+
+    /**
+     * Builds a {@link FindSongsInput} for find all songs.
+     *
+     * @param pageNumber the number of the current page (zero-index based)
+     * @param pageSize   the page size; thus is, the number of items to be returned
+     * @param sort       the sort to be used as part of any search query
+     * @return a new {@link FindSongsInput} with the given arguments
+     */
+    public static FindSongsInput of(
+            int pageNumber, int pageSize, Sort sort) {
+        return new FindSongsInput(pageNumber, pageSize, sort, null);
+    }
+
+    /**
+     * Builds a {@link FindSongsInput} for find songs of a given artist.
+     *
+     * @param artistId   the artist ID owner of the songs to be found
+     * @param pageNumber the number of the current page (zero-index based)
+     * @param pageSize   the page size; thus is, the number of items to be returned
+     * @param sort       the sort to be used as part of any search query
+     * @return a new {@link FindSongsInput} with the given arguments
+     */
+    public static FindSongsInput ofArtist(
+            Long artistId, int pageNumber, int pageSize, Sort sort) {
+        return new FindSongsInput(pageNumber, pageSize, sort, artistId);
+    }
+}

--- a/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/domain/songs/SongDTO.java
+++ b/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/domain/songs/SongDTO.java
@@ -1,0 +1,167 @@
+package io.davorpatech.apps.musicalsurveyor.domain.songs;
+
+import io.davorpatech.fwk.model.BaseValueObject;
+import io.davorpatech.fwk.model.Identifiable;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.io.Serial;
+import java.util.Objects;
+
+/**
+ * The Song DTO class.
+ *
+ * <p>Domain DTOs are immutable objects. As a DTO, it is a simple
+ * POJO that holds data and has no behavior.
+ *
+ * <p>It is used to transfer projected data between the persistence layer
+ * and the service layer. Also, it transfers this aggregated data from the
+ * service layer to the presentation layer.
+ */
+@Schema(
+    name = "Song",
+    description = """
+        In a context of a radio station, a song is a piece of music that can be
+        played on the radio. It is usually a single track from an album.
+        
+        A song can only have one artist and an artist can have many songs.
+        
+        Audience members of a radio station can respond to a survey by selecting
+        songs that they like and, a song can be selected by many audience members
+        as the way to know their musical preferences."""
+)
+public class SongDTO extends BaseValueObject implements Identifiable<Long> // NOSONAR
+{
+    @Serial
+    private static final long serialVersionUID = -1025429157975169469L;
+
+    @Schema(
+        description = "The song ID",
+        example = "1")
+    private final Long id;
+
+    @Schema(
+        description = "The artist ID owning the song",
+        example = "1")
+    private final Long artistId;
+
+    @Schema(
+        description = "The song title",
+        example = "Hey Jude")
+    private final String title;
+
+    @Schema(
+        description = "The song release year",
+        example = "1968")
+    private final Integer releaseYear;
+
+    @Schema(
+        description = "The song duration in seconds",
+        example = "431")
+    private final Integer duration;
+
+    @Schema(
+        description = "The musical genre of the song",
+        example = "Rock")
+    private final String genre;
+
+    /**
+     * Constructs a new {@link SongDTO} with the given arguments.
+     *
+     * @param id       the song ID
+     * @param artistId the artist ID owning the song
+     * @param title    the song title
+     * @param releaseYear the song release year
+     * @param duration    the song duration in seconds
+     * @param genre       the musical genre of the song
+     */
+    public SongDTO(Long id, Long artistId, String title, Integer releaseYear, Integer duration, String genre) {
+        super();
+        this.id = id;
+        this.artistId = artistId;
+        this.title = title;
+        this.releaseYear = releaseYear;
+        this.duration = duration;
+        this.genre = genre;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SongDTO other = (SongDTO) o;
+        return Objects.equals(id, other.id) &&
+            Objects.equals(artistId, other.artistId) &&
+            Objects.equals(title, other.title) &&
+            Objects.equals(releaseYear, other.releaseYear) &&
+            Objects.equals(duration, other.duration) &&
+            Objects.equals(genre, other.genre);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, artistId, title, releaseYear, duration, genre);
+    }
+
+    @Override
+    protected String defineObjAttrs() {
+        return String.format(
+            "id=%s, artistId=%s, title='%s', releaseYear=%s, duration=%s, genre=%s",
+            id, artistId, title, releaseYear, duration,
+            genre == null ? null : '\'' + genre + '\'');
+    }
+
+    /**
+     * Returns the song ID.
+     *
+     * @return the song ID
+     */
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * Returns the artist ID owning the song.
+     *
+     * @return the artist ID
+     */
+    public Long getArtistId() {
+        return artistId;
+    }
+
+    /**
+     * Returns the song title.
+     *
+     * @return the song title
+     */
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * Returns the song release year.
+     *
+     * @return the song release year
+     */
+    public Integer getReleaseYear() {
+        return releaseYear;
+    }
+
+    /**
+     * Returns the song duration in seconds.
+     *
+     * @return the song duration in seconds
+     */
+    public Integer getDuration() {
+        return duration;
+    }
+
+    /**
+     * Returns the musical genre of the song.
+     *
+     * @return the musical genre of the song
+     */
+    public String getGenre() {
+        return genre;
+    }
+}

--- a/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/domain/songs/SongWithArtistDTO.java
+++ b/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/domain/songs/SongWithArtistDTO.java
@@ -1,0 +1,259 @@
+package io.davorpatech.apps.musicalsurveyor.domain.songs;
+
+import io.davorpatech.fwk.model.BaseValueObject;
+import io.davorpatech.fwk.model.Identifiable;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.io.Serial;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * The SongWithArtist DTO class.
+ *
+ * <p>Domain DTOs are immutable objects. As a DTO, it is a simple
+ * POJO that holds data and has no behavior.
+ *
+ * <p>It is used to transfer projected data between the persistence layer
+ * and the service layer. Also, it transfers this aggregated data from the
+ * service layer to the presentation layer.
+ */
+@Schema(
+    name = "SongWithArtist",
+    description = """
+        In a context of a radio station, a song is a piece of music that can be
+        played on the radio. It is usually a single track from an album.
+        
+        A song can only have one artist and an artist can have many songs.
+        
+        Audience members of a radio station can respond to a survey by selecting
+        songs that they like and, a song can be selected by many audience members
+        as the way to know their musical preferences."""
+)
+public class SongWithArtistDTO extends BaseValueObject implements Identifiable<Long> // NOSONAR
+{
+    @Serial
+    private static final long serialVersionUID = -2370607780598749532L;
+
+    @Schema(
+        description = "The song ID",
+        example = "1")
+    private final Long id;
+
+    @Schema(
+        description = "The artist owning the song",
+        example = "The Beatles")
+    private final SongArtistDTO artist;
+
+    @Schema(
+        description = "The song title",
+        example = "Hey Jude")
+    private final String title;
+
+    @Schema(
+        description = "The song release year",
+        example = "1968")
+    private final Integer releaseYear;
+
+    @Schema(
+        description = "The song duration in seconds",
+        example = "431")
+    private final Integer duration;
+
+    @Schema(
+        description = "The musical genre of the song",
+        example = "Rock")
+    private final String genre;
+
+    /**
+     * Constructs a new {@link SongWithArtistDTO} with the given arguments.
+     *
+     * @param id          the song ID
+     * @param artist      the artist owning the song
+     * @param title       the song title
+     * @param releaseYear the song release year
+     * @param duration    the song duration in seconds
+     * @param genre       the musical genre of the song
+     */
+    public SongWithArtistDTO(Long id, SongArtistDTO artist,
+                             String title, Integer releaseYear, Integer duration, String genre) {
+        super();
+        this.id = id;
+        this.artist = artist;
+        this.title = title;
+        this.releaseYear = releaseYear;
+        this.duration = duration;
+        this.genre = genre;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SongWithArtistDTO other = (SongWithArtistDTO) o;
+        return Objects.equals(id, other.id) &&
+            Objects.equals(artist, other.artist) &&
+            Objects.equals(title, other.title) &&
+            Objects.equals(releaseYear, other.releaseYear) &&
+            Objects.equals(duration, other.duration) &&
+            Objects.equals(genre, other.genre);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, artist, title, releaseYear, duration, genre);
+    }
+
+    @Override
+    protected String defineObjAttrs() {
+        return String.format(
+            "id=%s, artist=%s, title='%s', releaseYear=%s, duration=%s, genre=%s",
+            id, Optional.ofNullable(artist)
+                // if artist is present, wrap its value in curly braces -> is a DTO
+                .map(value -> '{' + value.defineObjAttrs() + '}')
+                // if not present, return null
+                .orElse(null),
+            title, releaseYear, duration,
+            genre == null ? null : '\'' + genre + '\'');
+    }
+
+    /**
+     * Returns the song ID.
+     *
+     * @return the song ID
+     */
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * Returns the artist owning the song.
+     *
+     * @return the artist
+     */
+    public SongArtistDTO getArtist() {
+        return artist;
+    }
+
+    /**
+     * Returns the song title.
+     *
+     * @return the song title
+     */
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * Returns the song release year.
+     *
+     * @return the song release year
+     */
+    public Integer getReleaseYear() {
+        return releaseYear;
+    }
+
+    /**
+     * Returns the song duration in seconds.
+     *
+     * @return the song duration in seconds
+     */
+    public Integer getDuration() {
+        return duration;
+    }
+
+    /**
+     * Returns the musical genre of the song.
+     *
+     * @return the musical genre of the song
+     */
+    public String getGenre() {
+        return genre;
+    }
+
+    /**
+     * The SongArtist DTO class.
+     *
+     * <p>Domain DTOs are immutable objects. As a DTO, it is a simple
+     * POJO that holds data and has no behavior.
+     *
+     * <p>It is used to transfer projected data between the persistence layer
+     * and the service layer. Also, it transfers this aggregated data from the
+     * service layer to the presentation layer.
+     */
+    @Schema(
+        name = "SongArtist",
+        description = """
+            In a context of a radio station, an artist is a person or group of
+            people who create music.
+            
+            An artist can have many songs and a song can only have one artist.
+            """
+    )
+    public static class SongArtistDTO extends BaseValueObject implements Identifiable<Long> // NOSONAR
+    {
+        @Serial
+        private static final long serialVersionUID = -8590363304647348760L;
+
+        @Schema(
+            description = "The artist ID",
+            example = "1")
+        private final Long id;
+
+        @Schema(
+            description = "The artist name",
+            example = "The Beatles")
+        private final String name;
+
+        /**
+         * Constructs a new {@link SongArtistDTO} with the given arguments.
+         *
+         * @param id   the artist ID
+         * @param name the artist name
+         */
+        public SongArtistDTO(Long id, String name) {
+            super();
+            this.id = id;
+            this.name = name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            SongArtistDTO other = (SongArtistDTO) o;
+            return Objects.equals(id, other.id) &&
+                Objects.equals(name, other.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, name);
+        }
+
+        @Override
+        protected String defineObjAttrs() {
+            return String.format("id=%s, name='%s'", id, name);
+        }
+
+        /**
+         * Returns the artist ID.
+         *
+         * @return the artist ID
+         */
+        @Override
+        public Long getId() {
+            return id;
+        }
+
+        /**
+         * Returns the artist name.
+         *
+         * @return the artist name
+         */
+        public String getName() {
+            return name;
+        }
+    }
+}

--- a/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/domain/songs/UnableToTransferSongBetweenArtistsException.java
+++ b/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/domain/songs/UnableToTransferSongBetweenArtistsException.java
@@ -1,0 +1,107 @@
+package io.davorpatech.apps.musicalsurveyor.domain.songs;
+
+import io.davorpatech.fwk.exception.PreconditionalException;
+import io.davorpatech.fwk.model.AdditionalArgumentsPopulator;
+import io.davorpatech.fwk.model.ErrorDomain;
+import io.davorpatech.fwk.model.Identifiable;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * Exception raised when we try to change the song artist to another, thus is
+ * song transfering between artists is not allowed.
+ */
+@ResponseStatus(HttpStatus.PRECONDITION_FAILED)
+public class UnableToTransferSongBetweenArtistsException extends PreconditionalException // NOSONAR
+    implements Identifiable<Serializable>, ErrorDomain, AdditionalArgumentsPopulator // NOSONAR
+{
+    @Serial
+    private static final long serialVersionUID = 3994731842069594082L;
+
+    private final Serializable id;
+
+    private final Long fromArtistId;
+
+    private final Long toArtistId;
+
+    /**
+     * Construct a {@code ImmutableSongArtistException} with the specified arguments.
+     *
+     * @param id           the song ID we tried to transfer
+     * @param fromArtistId the identifier of the current artist owner of the song
+     *                     we tried to transfer
+     * @param toArtistId   the identifier of the artist we tried to transfer the
+     *                     song to
+     */
+    public UnableToTransferSongBetweenArtistsException(
+            Serializable id, Long fromArtistId, Long toArtistId) {
+        super(String.format(
+            "Unable to transfer the song identified by `%s` from artist `%s` to `%s`.",
+            id, fromArtistId, toArtistId));
+        this.id = id;
+        this.fromArtistId = fromArtistId;
+        this.toArtistId = toArtistId;
+    }
+
+    @Override
+    public String getDomain() {
+        return SongConstants.DOMAIN_NAME;
+    }
+
+    /**
+     * Returns the song ID where the business rule has been violated.
+     *
+     * @return the identifier of the song
+     */
+    @Override
+    public Serializable getId() {
+        return id;
+    }
+
+    /**
+     * Returns the affected field of the domain object.
+     *
+     * <p>In this case, the affected field is the {@code artist.id}.
+     *
+     * @return the affected field of the domain object
+     */
+    public String getFieldName() {
+        return "artist.id";
+    }
+
+    /**
+     * Returns the identifier of the current artist owner of the song
+     * we tried to transfer
+     *
+     * @return the identifier of the current artist owner of the song
+     *         we tried to transfer
+     */
+    public Long getFromArtistId() {
+        return fromArtistId;
+    }
+
+    /**
+     * Returns the rejected value, in this case the identifier of the artist
+     * we tried to transfer the song to.
+     *
+     * @return the identifier of the artist we tried to transfer the song to
+     */
+    public Long getToArtistId() {
+        return toArtistId;
+    }
+
+    @Override
+    public void populate(
+            final Environment environment,
+            final Map<String, Object> attributes)
+    {
+        attributes.put("field", getFieldName());
+        attributes.put("fromArtist", getFromArtistId());
+        attributes.put("toArtist", getToArtistId());
+    }
+}

--- a/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/domain/songs/UpdateSongInput.java
+++ b/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/domain/songs/UpdateSongInput.java
@@ -1,0 +1,148 @@
+package io.davorpatech.apps.musicalsurveyor.domain.songs;
+
+import io.davorpatech.apps.musicalsurveyor.domain.artist.CreateArtistInput;
+import io.davorpatech.apps.musicalsurveyor.domain.artist.UpdateArtistInput;
+import io.davorpatech.fwk.model.BaseValueObject;
+import io.davorpatech.fwk.model.commands.BaseUpdateInputCmd;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.io.Serial;
+import java.util.Objects;
+
+/**
+ * Input object for updating an existing {@code Song}.
+ *
+ * <p>Domain DTOs are immutable objects. As a DTO, it is a simple
+ * POJO that holds data and has no behavior. It is used to transfer
+ * data between the presentation layer and the services layer. It is
+ * also used to validate the data sent to the services layer. It is a
+ * good practice to use different DTOs for each one of service operations.
+ * This way, the DTOs can be extended in the future without breaking the
+ * service contract.
+ *
+ * <p>This is why the {@link CreateArtistInput} and the {@link UpdateArtistInput}
+ * are different classes. They both represent the same data, but the
+ * {@link UpdateArtistInput} has an additional {@code id} field. This is
+ * because the {@code id} is required to update an existing {@code Artist}.
+ * The {@code id} is not required to create a new {@code Artist} because
+ * the server will generate a new {@code id} for the new {@code Artist}.
+ *
+ * <p>As a domain DTO, it follows the {@link BaseValueObject} contract,
+ * which means that it identifiable field is fuzzy, and it can be compared
+ * for equality to other domain DTOs using all of its fields.
+ */
+public class UpdateSongInput extends BaseUpdateInputCmd<Long> // NOSONAR
+{
+    @Serial
+    private static final long serialVersionUID = -6095409350656142923L;
+
+    @NotNull
+    private final Long artistId;
+
+    @NotBlank
+    @Size(max = SongConstants.TITLE_MAXLEN)
+    private final String title;
+
+    @Min(SongConstants.RELEASE_YEAR_MIN)
+    private final Integer releaseYear;
+
+    @Min(SongConstants.DURATION_MIN)
+    private final Integer duration;
+
+    @Size(max = SongConstants.GENRE_MAXLEN)
+    private final String genre;
+
+    /**
+     * Constructs a new {@link UpdateSongInput} with the given arguments.
+     *
+     * @param id          the song ID
+     * @param artistId    the artist ID owning of the song
+     * @param title       the song title
+     * @param releaseYear the song release year
+     * @param duration    the song duration
+     * @param genre       the song genre
+     */
+    public UpdateSongInput(Long id, Long artistId,
+                           String title, Integer releaseYear, Integer duration, String genre) {
+        super(id);
+        this.artistId = artistId;
+        this.title = title;
+        this.releaseYear = releaseYear;
+        this.duration = duration;
+        this.genre = genre;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        UpdateSongInput other = (UpdateSongInput) o;
+        return Objects.equals(artistId, other.artistId) &&
+            Objects.equals(title, other.title) &&
+            Objects.equals(releaseYear, other.releaseYear) &&
+            Objects.equals(duration, other.duration) &&
+            Objects.equals(genre, other.genre);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), artistId,
+            title, releaseYear, duration, genre);
+    }
+
+    @Override
+    protected String defineObjAttrs() {
+        return String.format("%s, artistId=%s, title='%s', releaseYear=%s, duration=%s, genre=%s",
+            super.defineObjAttrs(), artistId, title, releaseYear, duration,
+            genre == null ? null : '\'' + genre + '\'');
+    }
+
+    /**
+     * Returns the artist ID owning of the song.
+     *
+     * @return the artist ID
+     */
+    public Long getArtistId() {
+        return artistId;
+    }
+
+    /**
+     * Returns the song title.
+     *
+     * @return the song title
+     */
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * Returns the song release year.
+     *
+     * @return the song release year
+     */
+    public Integer getReleaseYear() {
+        return releaseYear;
+    }
+
+    /**
+     * Returns the song duration.
+     *
+     * @return the song duration
+     */
+    public Integer getDuration() {
+        return duration;
+    }
+
+    /**
+     * Returns the song genre.
+     *
+     * @return the song genre
+     */
+    public String getGenre() {
+        return genre;
+    }
+}

--- a/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/services/songs/SongService.java
+++ b/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/services/songs/SongService.java
@@ -1,0 +1,44 @@
+package io.davorpatech.apps.musicalsurveyor.services.songs;
+
+import io.davorpatech.apps.musicalsurveyor.domain.songs.CreateSongInput;
+import io.davorpatech.apps.musicalsurveyor.domain.songs.FindSongsInput;
+import io.davorpatech.apps.musicalsurveyor.domain.songs.SongWithArtistDTO;
+import io.davorpatech.apps.musicalsurveyor.domain.songs.UpdateSongInput;
+import io.davorpatech.apps.musicalsurveyor.persistence.model.Song;
+import io.davorpatech.fwk.exception.NoSuchEntityException;
+import io.davorpatech.fwk.service.data.DataService;
+import org.springframework.lang.NonNull;
+
+/**
+ * Service for managing {@link Song} data domain.
+ */
+public interface SongService extends DataService<
+        Long, Song, SongWithArtistDTO,
+        FindSongsInput, CreateSongInput, UpdateSongInput> // NOSONAR
+{
+    /**
+     * Retrieves the detail of a song by its identifier if is part of
+     * the given artist repertoire.
+     *
+     * @param artistId the identifier of the artist owner of the song
+     * @param songId   the identifier of the song
+     * @return the song with the given identifiers
+     * @throws NoSuchEntityException if the record identified by the given
+     *         {@literal ids} is not found
+     */
+    @NonNull
+    SongWithArtistDTO findInArtistRepertoire(
+        final @NonNull Long artistId, final @NonNull Long songId);
+
+    /**
+     * Removes a song by its identifier only if is part of the given
+     * artist repertoire.
+     *
+     * @param artistId the identifier of the artist owner of the song
+     * @param songId   the identifier of the song
+     * @throws NoSuchEntityException if the record identified by the given
+     *         {@literal ids} is not found
+     */
+    void deleteFromArtistRepertoire(
+        final @NonNull Long artistId, final @NonNull Long songId);
+}

--- a/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/services/songs/SongServiceImpl.java
+++ b/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/services/songs/SongServiceImpl.java
@@ -1,0 +1,183 @@
+package io.davorpatech.apps.musicalsurveyor.services.songs;
+
+import io.davorpatech.apps.musicalsurveyor.domain.artist.ArtistConstants;
+import io.davorpatech.apps.musicalsurveyor.domain.songs.*;
+import io.davorpatech.apps.musicalsurveyor.persistence.dao.ArtistRepository;
+import io.davorpatech.apps.musicalsurveyor.persistence.dao.SongRepository;
+import io.davorpatech.apps.musicalsurveyor.persistence.model.Artist;
+import io.davorpatech.apps.musicalsurveyor.persistence.model.Song;
+import io.davorpatech.fwk.exception.EntityUsedByForeignsException;
+import io.davorpatech.fwk.exception.NoSuchEntityException;
+import io.davorpatech.fwk.exception.NoSuchForeignalEntityException;
+import io.davorpatech.fwk.service.data.jpa.JpaBasedDataService;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.springframework.data.domain.Example;
+import org.springframework.data.domain.Sort;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Implementation of {@link SongService}.
+ *
+ * <p>As a service, it is a stateless class that provides operations
+ * to manage {@link Song} data domain.
+ *
+ * <p>Services are the entry point to the business logic. They are
+ * responsible for handling the data flow between the presentation
+ * layer and the persistence layer, and vice versa.
+ */
+@Service
+@Transactional(readOnly = true)
+public class SongServiceImpl extends JpaBasedDataService<
+        SongRepository,
+        Long, Song, SongWithArtistDTO,
+        FindSongsInput, CreateSongInput, UpdateSongInput>
+    implements SongService // NOSONAR
+{
+    private final ArtistRepository artistRepository;
+
+    /**
+     * Constructs a new {@link SongServiceImpl} with the given arguments.
+     *
+     * @param songRepository     the song repository, never {@code null}
+     * @param artistRepository   the artist repository, never {@code null}
+     */
+    SongServiceImpl(SongRepository songRepository,
+                    ArtistRepository artistRepository)
+    {
+        super(songRepository, SongConstants.DOMAIN_NAME);
+        Assert.notNull(artistRepository, "ArtistRepository must not be null!");
+        this.artistRepository = artistRepository;
+    }
+
+    @Override
+    protected @NonNull Sort getDefaultFindSort() {
+        return Sort.by(
+            Sort.Order.asc("artist.id"),
+            Sort.Order.asc("id"));
+    }
+
+    @Override
+    protected Example<Song> determineFindFilters(@NonNull FindSongsInput query) {
+        final Long artistId = query.getArtistId();
+        if (artistId == null) return super.determineFindFilters(query);
+        // build the probe entity to filter by artistId
+        Artist artist = new Artist();
+        artist.setId(artistId);
+        Song song = new Song();
+        song.setArtist(artist);
+        return Example.of(song);
+    }
+
+    @Override
+    protected @NonNull SongWithArtistDTO convertEntityToDto(@NonNull Song entity) {
+        final SongWithArtistDTO.SongArtistDTO artist = Optional
+            .ofNullable(entity.getArtist())
+            .map(value -> new SongWithArtistDTO.SongArtistDTO(
+                                value.getId(), value.getName()))
+            .orElse(null);
+        return new SongWithArtistDTO(
+                entity.getId(), artist,
+                entity.getTitle(),
+                entity.getReleaseYear(),
+                entity.getDuration(),
+                entity.getGenre());
+    }
+
+    @Override
+    protected Song convertCreateToEntity(CreateSongInput input) {
+        // first find its artist
+        final Long artistId = input.getArtistId();
+        final Artist artist = artistRepository
+            .findById(artistId)
+            .orElseThrow(NoSuchForeignalEntityException.creater(
+                ArtistConstants.DOMAIN_NAME, artistId));
+        // then map song properties
+        Song entity = new Song();
+        entity.setTitle(input.getTitle());
+        entity.setReleaseYear(input.getReleaseYear());
+        entity.setDuration(input.getDuration());
+        entity.setGenre(input.getGenre());
+        artist.addSong(entity);
+        return entity;
+    }
+
+    @Override
+    protected void populateEntityToUpdate(
+            @NonNull Song entity, @NonNull UpdateSongInput input) {
+        // first find its artist
+        final Long currentArtistId = entity.getArtistId();
+        final Long artistId = input.getArtistId();
+        if (!Objects.equals(currentArtistId, artistId)) {
+            // checking business rule to prevent transfer song between artists
+            throw new UnableToTransferSongBetweenArtistsException(
+                entity.getId(), currentArtistId, artistId);
+        }
+        final Artist artist = artistRepository
+            .findById(artistId)
+            .orElseThrow(NoSuchForeignalEntityException.creater(
+                ArtistConstants.DOMAIN_NAME, artistId));
+        // then map song properties
+        entity.setArtist(artist);
+        entity.setTitle(input.getTitle());
+        entity.setReleaseYear(input.getReleaseYear());
+        entity.setDuration(input.getDuration());
+        entity.setGenre(input.getGenre());
+    }
+
+    @Override
+    public @NonNull SongWithArtistDTO findInArtistRepertoire(
+            @NonNull Long artistId, @NonNull Long songId) {
+        // check if artist exists
+        Optional.of(artistId)
+            .map(artistRepository::existsById)
+            .filter(Boolean.TRUE::equals)
+            .orElseThrow(NoSuchForeignalEntityException.creater( // NOSONAR
+                ArtistConstants.DOMAIN_NAME, artistId));
+        // retrieve checking if song exists
+        final Song entity = repository.findInArtistRepertoire(artistId, songId)
+            .orElseThrow(NoSuchEntityException.creater(domainName, songId));
+        return convertEntityToDto(entity);
+    }
+
+    @Override
+    protected void checkEntityDeletion(Song entity) {
+        ensureEmptyParticipationResponses(null, entity.getId());
+    }
+
+    @Transactional
+    @Override
+    public void deleteFromArtistRepertoire(
+            @NonNull Long artistId, @NonNull Long songId) {
+        // business rule: prevent remove song if it has participation responses
+        ensureEmptyParticipationResponses(artistId, songId);
+        // remove counting the number of deleted entities
+        int affectedRows = repository.deleteFromArtistRepertoire(artistId, songId);
+        if (affectedRows == 0) { // no deletion performed
+            // test if reason is a missing artist or song
+            if (artistRepository.existsById(artistId)) {
+                throw new NoSuchEntityException(domainName, songId);
+            }
+            throw new NoSuchForeignalEntityException(ArtistConstants.DOMAIN_NAME, artistId);
+        }
+        if (affectedRows > 1) { // more than one deletion performed
+            throw new IncorrectResultSizeDataAccessException(1, affectedRows);
+        }
+    }
+
+    protected void ensureEmptyParticipationResponses(@Nullable Long artistId, @NonNull Long songId) {
+        long count = artistId == null
+            ? repository.countByParticipationResponses(songId)
+            : repository.countByParticipationResponses(artistId, songId);
+        if (count > 0) {
+            throw new EntityUsedByForeignsException(
+                domainName, songId, "musicpoll.SurveyParticipationResponse", count);
+        }
+    }
+}

--- a/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/web/controller/ArtistSongsController.java
+++ b/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/web/controller/ArtistSongsController.java
@@ -1,0 +1,297 @@
+package io.davorpatech.apps.musicalsurveyor.web.controller;
+
+import io.davorpatech.apps.musicalsurveyor.domain.songs.CreateSongInput;
+import io.davorpatech.apps.musicalsurveyor.domain.songs.FindSongsInput;
+import io.davorpatech.apps.musicalsurveyor.domain.songs.SongWithArtistDTO;
+import io.davorpatech.apps.musicalsurveyor.domain.songs.UpdateSongInput;
+import io.davorpatech.apps.musicalsurveyor.services.songs.SongService;
+import io.davorpatech.apps.musicalsurveyor.web.model.songs.CreateSongRequest;
+import io.davorpatech.apps.musicalsurveyor.web.model.songs.UpdateSongRequest;
+import io.davorpatech.fwk.exception.NoMatchingRelatedFieldsException;
+import io.davorpatech.fwk.model.PagedResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.Assert;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+import java.util.Objects;
+
+/**
+ * REST controller for managing {@code Song} resources related with a
+ * given {@code Artist}.
+ *
+ * <p>As a controller, it is a stateless class that provides operations
+ * to manage {@code Artist} data domain. It exposes endpoints that
+ * handle HTTP requests such as GET, POST, PUT, and DELETE. It also
+ * provides a way to map request parameters to the method arguments
+ * using the {@link RequestParam @RequestParam} annotation. It also
+ * provides a way to map request body to the method arguments using the
+ * {@link RequestBody @RequestBody} annotation. It also provides a way
+ * to map request path variables to the method arguments using the
+ * {@link PathVariable @PathVariable} annotation.
+ *
+ * <p>Controllers are the entry point to the presentation layer. They are
+ * responsible for handling the HTTP requests, and they delegate the
+ * business logic to the services.
+ */
+@RestController
+@RequestMapping("/api/artists/{artistId}/songs")
+public class ArtistSongsController // NOSONAR
+{
+    private final SongService songService;
+
+    /**
+     * Constructs a new {@link SongController} with the given arguments.
+     *
+     * @param songService the song service, never {@code null}
+     */
+    ArtistSongsController(SongService songService) {
+        Assert.notNull(songService, "SongService must not be null!");
+        this.songService = songService;
+    }
+
+    /**
+     * Finds all {@code Song} resources part of repertoire of the given
+     * {@code Artist}.
+     *
+     * @param artistId     the identifier of the artist to find its song repertoire
+     * @param pageable     the page and sorting parameters to be applied
+     * @param forceUnpaged whether to force an unpaged result
+     * @return all {@code Song} resources
+     */
+    @Operation(
+        summary = "Finds the songs part of the artist repertoire",
+        description = """
+            Finds all songs part of the artist repertoire.
+            
+            The results can be paginated and sorted.""",
+        tags = { "artist", "song" }
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "Successful operation",
+        useReturnTypeSchema = true)
+    @ApiResponse(
+        responseCode = "400",
+        description = "Request parameters are invalid",
+        content = @Content)
+    @GetMapping
+    PagedResult<SongWithArtistDTO> findAll(
+        @Parameter(example = "1")
+        @PathVariable("artistId") Long artistId,
+        @ParameterObject
+        Pageable pageable,
+        @RequestParam(value = "unpaged", defaultValue = "false") boolean forceUnpaged)
+    {
+        FindSongsInput query = FindSongsInput.ofArtist(
+            artistId,
+            forceUnpaged || pageable.isUnpaged() ?  0 : pageable.getPageNumber(),
+            forceUnpaged || pageable.isUnpaged() ? -1 : pageable.getPageSize(),
+            pageable.getSort()
+        );
+        return songService.findAll(query);
+    }
+
+    /**
+     * Finds a {@code Song} resource inside the repertoire of a given
+     * {@code Artist}.
+     *
+     * @param artistId the identifier of the artist wherein find the song
+     * @param songId   the identifier of the song to find
+     * @return the {@code Song} resource
+     */
+    @Operation(
+        summary = "Finds a song part of the artist repertoire",
+        description = """
+            Finds a song part of the artist repertoire.
+            
+            The identifiers are numeric values.""",
+        tags = { "artist", "song" }
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "Successful operation",
+        useReturnTypeSchema = true)
+    @ApiResponse(
+        responseCode = "400",
+        description = "Request parameters are invalid",
+        content = @Content)
+    @ApiResponse(
+        responseCode = "404",
+        description = "Artist or song not found",
+        content = @Content)
+    @GetMapping("/{songId}")
+    ResponseEntity<SongWithArtistDTO> retrieveById(
+        @Parameter(example = "1")
+        @PathVariable("artistId") Long artistId,
+        @Parameter(example = "1")
+        @PathVariable("songId") Long songId)
+    {
+        SongWithArtistDTO song = songService.findInArtistRepertoire(artistId, songId);
+        return ResponseEntity.ok(song);
+    }
+
+    /**
+     * Creates a new {@code Song} resource inside the repertoire of a given
+     * {@code Artist} using the given arguments.
+     *
+     * @param artistId the identifier of the artist wherein create the song
+     *                 resource
+     * @param request  the request body containing the parameters
+     * @return the created {@code Song} resource
+     */
+    @Operation(
+        summary = "Creates a new song part of the artist repertoire",
+        description = """
+            Creates a new song part of the artist repertoire.
+            
+            The request body must contain the parameters.""",
+        tags = { "artist", "song" }
+    )
+    @ApiResponse(
+        responseCode = "201",
+        description = "Successful operation",
+        useReturnTypeSchema = true)
+    @ApiResponse(
+        responseCode = "400",
+        description = "Request parameters are invalid",
+        content = @Content)
+    @ApiResponse(
+        responseCode = "404",
+        description = "Artist not found",
+        content = @Content)
+    @PostMapping
+    ResponseEntity<SongWithArtistDTO> create(
+        @Parameter(example = "1")
+        @PathVariable("artistId") Long artistId,
+        @RequestBody @Validated CreateSongRequest request)
+    {
+        if (request.hasArtistId() && !Objects.equals(artistId, request.getArtistId())) {
+            throw new NoMatchingRelatedFieldsException(
+                "create.artistId", artistId, "create.request.artistId", request.getArtistId());
+        }
+        CreateSongInput input = new CreateSongInput(
+            artistId,
+            request.getTitle(), request.getReleaseYear(),
+            request.getDuration(), request.getGenre());
+        SongWithArtistDTO dto = songService.create(input);
+
+        // Compose URI Location of the retrieve endpoint for this created resource
+        final URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+            .path("/{id}")
+            .buildAndExpand(dto.getId())
+            .toUri();
+        // build response entity providing URI and body of the created resource
+        return ResponseEntity.created(location).body(dto);
+    }
+
+    /**
+     * Updates a {@code Song} resource inside the repertoire of a given
+     * {@code Artist} using the given arguments.
+     *
+     * @param artistId the identifier of the artist that owns the song to update
+     * @param songId   the identifier of the song to update
+     * @param request  the request body containing the parameters
+     * @return the updated {@code Song} resource
+     */
+    @Operation(
+        summary = "Updates a song part of the artist repertoire",
+        description = """
+            Updates a song part of the artist repertoire.
+            
+            The request body must contain the parameters.
+            
+            The identifiers are numeric values.""",
+        tags = { "artist", "song" }
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "Successful operation",
+        useReturnTypeSchema = true)
+    @ApiResponse(
+        responseCode = "400",
+        description = "Request parameters are invalid",
+        content = @Content)
+    @ApiResponse(
+        responseCode = "404",
+        description = "Artist or song not found",
+        content = @Content)
+    @ApiResponse(
+        responseCode = "412",
+        description = "Song cannot be transferred to another artist",
+        content = @Content)
+    @PutMapping("/{songId}")
+    ResponseEntity<SongWithArtistDTO> update(
+        @Parameter(example = "1")
+        @PathVariable("artistId") Long artistId,
+        @Parameter(example = "1")
+        @PathVariable("songId") Long songId,
+        @RequestBody @Validated UpdateSongRequest request)
+    {
+        if (request.hasArtistId() && !Objects.equals(artistId, request.getArtistId())) {
+            throw new NoMatchingRelatedFieldsException(
+                "update.artistId", artistId, "update.request.artistId", request.getArtistId());
+        }
+        if (request.hasId() && !Objects.equals(songId, request.getId())) {
+            throw new NoMatchingRelatedFieldsException(
+                "update.songId", songId, "update.request.id", request.getId());
+        }
+        UpdateSongInput input = new UpdateSongInput(songId, artistId,
+            request.getTitle(), request.getReleaseYear(),
+            request.getDuration(), request.getGenre());
+        SongWithArtistDTO dto = songService.update(input);
+        return ResponseEntity.ok(dto);
+    }
+
+    /**
+     * Deletes a {@code Song} resource inside the repertoire of a given
+     * {@code Artist}.
+     *
+     * @param artistId the identifier of the artist wherein delete the song
+     * @param songId   the identifier of the song to delete
+     * @return the {@code Song} resource deleted
+     */
+    @Operation(
+        summary = "Deletes a song part of the artist repertoire",
+        description = """
+            Deletes a song part of the artist repertoire.
+            
+            The identifiers are numeric values.""",
+        tags = { "artist", "song" }
+    )
+    @ApiResponse(
+        responseCode = "204",
+        description = "Successful operation",
+        useReturnTypeSchema = true)
+    @ApiResponse(
+        responseCode = "400",
+        description = "Request parameters are invalid",
+        content = @Content)
+    @ApiResponse(
+        responseCode = "404",
+        description = "Artist or song not found",
+        content = @Content)
+    @ApiResponse(
+        responseCode = "409",
+        description = "Song cannot be deleted",
+        content = @Content)
+    @DeleteMapping("/{songId}")
+    ResponseEntity<Void> delete(
+        @Parameter(example = "1")
+        @PathVariable("artistId") Long artistId,
+        @Parameter(example = "1")
+        @PathVariable("songId") Long songId)
+    {
+        songService.deleteFromArtistRepertoire(artistId, songId);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/web/controller/SongController.java
+++ b/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/web/controller/SongController.java
@@ -1,0 +1,130 @@
+package io.davorpatech.apps.musicalsurveyor.web.controller;
+
+import io.davorpatech.apps.musicalsurveyor.domain.songs.FindSongsInput;
+import io.davorpatech.apps.musicalsurveyor.domain.songs.SongWithArtistDTO;
+import io.davorpatech.apps.musicalsurveyor.services.songs.SongService;
+import io.davorpatech.fwk.model.PagedResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.Assert;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * REST controller for managing {@code Song} resources.
+ *
+ * <p>As a controller, it is a stateless class that provides operations
+ * to manage {@code Artist} data domain. It exposes endpoints that
+ * handle HTTP requests such as GET, POST, PUT, and DELETE. It also
+ * provides a way to map request parameters to the method arguments
+ * using the {@link RequestParam @RequestParam} annotation. It also
+ * provides a way to map request body to the method arguments using the
+ * {@link org.springframework.web.bind.annotation.RequestBody @RequestBody}
+ * annotation. It also provides a way to map request path variables to the
+ * method arguments using the {@link org.springframework.web.bind.annotation.PathVariable
+ * @PathVariable} annotation.
+ *
+ * <p>Controllers are the entry point to the presentation layer. They are
+ * responsible for handling the HTTP requests, and they delegate the
+ * business logic to the services.
+ */
+@Tag(
+    name = "song",
+    description = """
+        The Songs API.
+        
+        Provides REST operations to manage Songs resources."""
+)
+@RestController
+@RequestMapping("/api/songs")
+public class SongController // NOSONAR
+{
+    private final SongService songService;
+
+    /**
+     * Constructs a new {@link SongController} with the given arguments.
+     * 
+     * @param songService the song service, never {@code null}
+     */
+    SongController(SongService songService) {
+        Assert.notNull(songService, "SongService must not be null!");
+        this.songService = songService;
+    }
+
+    /**
+     * Finds all {@code Song} resources.
+     *
+     * @param pageable     the page and sorting parameters to be applied
+     * @param forceUnpaged whether to force an unpaged result
+     * @return all {@code Song} resources
+     */
+    @Operation(
+        summary = "Finds all songs",
+        description = """
+            Finds all songs.
+            
+            The results can be paginated and sorted.""",
+        tags = { "song" }
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "Successful operation",
+        useReturnTypeSchema = true)
+    @ApiResponse(
+        responseCode = "400",
+        description = "Request parameters are invalid",
+        content = @Content)
+    @GetMapping
+    PagedResult<SongWithArtistDTO> findAll(
+        @ParameterObject
+        Pageable pageable,
+        @RequestParam(value = "unpaged", defaultValue = "false") boolean forceUnpaged)
+    {
+        FindSongsInput query = FindSongsInput.of(
+            forceUnpaged || pageable.isUnpaged() ?  0 : pageable.getPageNumber(),
+            forceUnpaged || pageable.isUnpaged() ? -1 : pageable.getPageSize(),
+            pageable.getSort()
+        );
+        return songService.findAll(query);
+    }
+
+    /**
+     * Retrieves the detail of a {@code Song} resource given its ID.
+     *
+     * @param id the ID of the resource to be retrieved
+     * @return the {@code Song} resource matching the given ID
+     */
+    @Operation(
+        summary = "Retrieves a song detail by its ID",
+        description = """
+            Retrieves the song detail by its identifier.
+            
+            The identifier is a numeric value.""",
+        tags = { "song" }
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "Successful operation",
+        useReturnTypeSchema = true)
+    @ApiResponse(
+        responseCode = "400",
+        description = "Request parameters are invalid",
+        content = @Content)
+    @ApiResponse(
+        responseCode = "404",
+        description = "The song is not found",
+        content = @Content)
+    @GetMapping("/{id}")
+    ResponseEntity<SongWithArtistDTO> retrieveById(
+        @Parameter(description = "The identifier of the song to be retrieved", example = "1")
+        @PathVariable("id") Long id)
+    {
+        SongWithArtistDTO dto = songService.findById(id);
+        return ResponseEntity.ok(dto);
+    }
+}

--- a/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/web/model/songs/CreateSongRequest.java
+++ b/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/web/model/songs/CreateSongRequest.java
@@ -1,0 +1,173 @@
+package io.davorpatech.apps.musicalsurveyor.web.model.songs;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.davorpatech.apps.musicalsurveyor.domain.songs.SongConstants;
+import io.davorpatech.fwk.model.BaseValueObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.io.Serial;
+import java.util.Objects;
+
+/**
+ * Represents the HTTP request body to create a new {@code Song}
+ * part of the repertoire of a given {@code Artist}.
+ *
+ * <p>Request DTOs are immutable objects. As a DTO, it is a simple
+ * POJO that holds data and has no behavior. It is used to transfer
+ * data between the client and the server. It is also used to validate
+ * the data sent to the server. It is a good practice to use different
+ * DTOs for the request and the response. This way, the response DTO
+ * can be extended in the future without breaking the client. This
+ * is not the case for the request DTO, which should be kept as simple
+ * as possible.
+ *
+ * <p>This is why the {@link CreateSongRequest} and the
+ * {@link UpdateSongRequest} are different classes. They both
+ * represent the same data, but the {@link UpdateSongRequest} has
+ * an additional {@code id} field. This is because the {@code id} is
+ * required to update an existing {@code Song}. The {@code id} is not
+ * required to create a new {@code Song} because the server will generate
+ * a new {@code id} for the new {@code Song}.
+ */
+@Schema(
+    name = "CreateSongRequest",
+    description = "Represents the HTTP request body to create a new Song."
+)
+public class CreateSongRequest extends BaseValueObject // NOSONAR
+{
+    @Serial
+    private static final long serialVersionUID = -7651856310750208976L;
+
+    @Schema(
+        description = "The artist ID",
+        example = "1",
+        hidden = true)
+    private final Long artistId;
+
+    @Schema(
+        description = "The song title",
+        example = "Yesterday")
+    @NotBlank
+    @Size(max = SongConstants.TITLE_MAXLEN)
+    private final String title;
+
+    @Schema(
+        description = "The song release year",
+        example = "1965")
+    @Min(SongConstants.RELEASE_YEAR_MIN)
+    private final Integer releaseYear;
+
+    @Schema(
+        description = "The song duration in seconds",
+        example = "120")
+    @Min(SongConstants.DURATION_MIN)
+    private final Integer duration;
+
+    @Schema(
+        description = "The song genre",
+        example = "Rock")
+    @Size(max = SongConstants.GENRE_MAXLEN)
+    private final String genre;
+
+    /**
+     * Constructs a new {@link CreateSongRequest} with the given
+     * arguments.
+     *
+     * @param artistId     the artist ID
+     * @param title        the song title
+     * @param releaseYear  the song release year
+     * @param duration     the song duration
+     * @param genre        the song genre
+     */
+    @JsonCreator
+    public CreateSongRequest(Long artistId, String title, Integer releaseYear, Integer duration, String genre) {
+        super();
+        this.artistId = artistId;
+        this.title = title;
+        this.releaseYear = releaseYear;
+        this.duration = duration;
+        this.genre = genre;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CreateSongRequest other = (CreateSongRequest) o;
+        return Objects.equals(artistId, other.artistId) &&
+            Objects.equals(title, other.title) &&
+            Objects.equals(releaseYear, other.releaseYear) &&
+            Objects.equals(duration, other.duration) &&
+            Objects.equals(genre, other.genre);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(artistId, title, releaseYear, duration, genre);
+    }
+
+    @Override
+    protected String defineObjAttrs() {
+        return String.format(
+            "artistId=%s, title='%s', releaseYear=%s, duration=%s, genre=%s",
+            artistId, title, releaseYear, duration,
+            genre == null ? null : '\'' + genre + '\'');
+    }
+
+    /**
+     * Returns the artist ID.
+     *
+     * @return the artist ID
+     */
+    public Long getArtistId() {
+        return artistId;
+    }
+
+    /**
+     * Returns whether the artist ID is present.
+     *
+     * @return {@code true} if the artist ID is present, {@code false} otherwise
+     */
+    public boolean hasArtistId() {
+        return artistId != null;
+    }
+
+    /**
+     * Returns the song title.
+     *
+     * @return the song title
+     */
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * Returns the song release year.
+     *
+     * @return the song release year
+     */
+    public Integer getReleaseYear() {
+        return releaseYear;
+    }
+
+    /**
+     * Returns the song duration in seconds.
+     *
+     * @return the song duration in seconds
+     */
+    public Integer getDuration() {
+        return duration;
+    }
+
+    /**
+     * Returns the musical genre of the song.
+     *
+     * @return the musical genre of the song
+     */
+    public String getGenre() {
+        return genre;
+    }
+}

--- a/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/web/model/songs/UpdateSongRequest.java
+++ b/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/web/model/songs/UpdateSongRequest.java
@@ -1,0 +1,182 @@
+package io.davorpatech.apps.musicalsurveyor.web.model.songs;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.davorpatech.apps.musicalsurveyor.domain.songs.SongConstants;
+import io.davorpatech.fwk.model.BaseValueObject;
+import io.davorpatech.fwk.model.Identifiable;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.io.Serial;
+import java.util.Objects;
+
+/**
+ * Represents the HTTP request body to update an existing {@code Song}.
+ *
+ * <p>Request DTOs are immutable objects. As a DTO, it is a simple
+ * POJO that holds data and has no behavior. It is used to transfer
+ * data between the client and the server. It is also used to validate
+ * the data sent to the server. It is a good practice to use different
+ * DTOs for the request and the response. This way, the response DTO
+ * can be extended in the future without breaking the client. This
+ * is not the case for the request DTO, which should be kept as simple
+ * as possible.
+ *
+ * <p>This is why the {@link CreateSongRequest} and the {@link UpdateSongRequest}
+ * are different classes. They both represent the same data, but the
+ * {@link UpdateSongRequest} has an additional {@code id} field. This is
+ * because the {@code id} is required to update an existing {@code Song}. The
+ * {@code id} is not required to create a new {@code Song} because the server
+ * will generate a new {@code id} for the new {@code Song}.
+ */
+@Schema(
+    name = "UpdateSongRequest",
+    description = "Represents the HTTP request body to update an existing Song."
+)
+public class UpdateSongRequest extends BaseValueObject implements Identifiable<Long> // NOSONAR
+{
+    @Serial
+    private static final long serialVersionUID = -318529779235074044L;
+
+    @Schema(
+        description = "The song ID",
+        example = "1",
+        hidden = true)
+    private final Long id;
+
+    @Schema(
+        description = "The artist ID",
+        example = "1",
+        hidden = true)
+    private final Long artistId;
+
+    @Schema(
+        description = "The song title",
+        example = "Yesterday")
+    @NotBlank
+    @Size(max = SongConstants.TITLE_MAXLEN)
+    private final String title;
+
+    @Schema(
+        description = "The song release year",
+        example = "1965")
+    @Min(SongConstants.RELEASE_YEAR_MIN)
+    private final Integer releaseYear;
+
+    @Schema(
+        description = "The song duration in seconds",
+        example = "120")
+    @Min(SongConstants.DURATION_MIN)
+    private final Integer duration;
+
+    @Schema(
+        description = "The song genre",
+        example = "Rock")
+    @Size(max = SongConstants.GENRE_MAXLEN)
+    private final String genre;
+
+    /**
+     * Constructs a new {@link UpdateSongRequest} with the given
+     * arguments.
+     *
+     * @param id           the song ID
+     * @param artistId     the artist ID
+     * @param title        the song title
+     * @param releaseYear  the song release year
+     * @param duration     the song duration
+     * @param genre        the song genre
+     */
+    @JsonCreator
+    public UpdateSongRequest(Long id, Long artistId,
+                             String title, Integer releaseYear, Integer duration, String genre) {
+        super();
+        this.id = id;
+        this.artistId = artistId;
+        this.title = title;
+        this.releaseYear = releaseYear;
+        this.duration = duration;
+        this.genre = genre;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UpdateSongRequest other = (UpdateSongRequest) o;
+        return Objects.equals(id, other.id) &&
+            Objects.equals(artistId, other.artistId) &&
+            Objects.equals(title, other.title) &&
+            Objects.equals(releaseYear, other.releaseYear) &&
+            Objects.equals(duration, other.duration) &&
+            Objects.equals(genre, other.genre);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, artistId, title, releaseYear, duration, genre);
+    }
+
+    @Override
+    protected String defineObjAttrs() {
+        return String.format(
+            "id=%s, artistId=%s, title='%s', releaseYear=%s, duration=%s, genre=%s",
+            id, artistId, title, releaseYear, duration,
+            genre == null ? null : '\'' + genre + '\'');
+    }
+
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * Returns the artist ID.
+     *
+     * @return the artist ID
+     */
+    public Long getArtistId() {
+        return artistId;
+    }
+
+    public boolean hasArtistId() {
+        return artistId != null;
+    }
+
+    /**
+     * Returns the song title.
+     *
+     * @return the song title
+     */
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * Returns the song release year.
+     *
+     * @return the song release year
+     */
+    public Integer getReleaseYear() {
+        return releaseYear;
+    }
+
+    /**
+     * Returns the song duration in seconds.
+     *
+     * @return the song duration in seconds
+     */
+    public Integer getDuration() {
+        return duration;
+    }
+
+    /**
+     * Returns the musical genre of the song.
+     *
+     * @return the musical genre of the song
+     */
+    public String getGenre() {
+        return genre;
+    }
+}


### PR DESCRIPTION
This PR follows to develop with the Songs functionality.

It adds classes for:

- A Song service
- The Song REST controller
- The Song DTOs related with the service: find, create, update
- The create, update requests and get responses DTOs

Also implements the business rules that restricts:

- Transfer songs between artists
- Delete songs associated with some survey participation