### PR TITLE
Implementando reglas de negocio para `Prize`

### DIFF
--- a/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/domain/prizes/PrizeTitleAlreadyExistsException.java
+++ b/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/domain/prizes/PrizeTitleAlreadyExistsException.java
@@ -1,0 +1,90 @@
+package io.davorpatech.apps.musicalsurveyor.domain.prizes;
+
+import io.davorpatech.fwk.exception.PreconditionalException;
+import io.davorpatech.fwk.model.AdditionalArgumentsPopulator;
+import io.davorpatech.fwk.model.ErrorDomain;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.io.Serial;
+import java.util.Map;
+
+/**
+ * Exception that is thrown when the detail of a specific model object
+ * (entity, POJO, DTO...) already exists when searching for any of its
+ * identifiers.
+ *
+ * <p>This will normally be used to indicate that a database Unique or
+ * Primary Key has been violated. In this case, the affected field is
+ * the {@code title} of the {@code Prize} domain object.
+ */
+@ResponseStatus(HttpStatus.CONFLICT)
+public class PrizeTitleAlreadyExistsException extends PreconditionalException // NOSONAR
+        implements ErrorDomain, AdditionalArgumentsPopulator // NOSONAR
+{
+    @Serial
+    private static final long serialVersionUID = -1253316887668366131L;
+
+    private final String prizeTitle;
+
+    /**
+     * Construct a {@code PrizeTitleAlreadyExistsException} with the specified
+     * arguments.
+     *
+     * @param prizeTitle the affected prize title
+     */
+    public PrizeTitleAlreadyExistsException(String prizeTitle) {
+        super(String.format("The prize title `%s` already exist.", prizeTitle));
+        this.prizeTitle = prizeTitle;
+    }
+
+    /**
+     * Construct a {@code PrizeTitleAlreadyExistsException} with the specified
+     * arguments.
+     *
+     * @param prizeTitle the affected prize title
+     * @param cause      the cause. It can be {@code null}
+     */
+    public PrizeTitleAlreadyExistsException(String prizeTitle, Throwable cause) {
+        this(prizeTitle);
+        initCause(cause);
+    }
+
+    @Override
+    public String getDomain() {
+        return PrizeConstants.DOMAIN_NAME;
+    }
+
+    /**
+     * Returns the affected field the domain object.
+     *
+     * <p>In this case, the affected field is the {@code email}.
+     *
+     * @return the affected field of the domain object
+     */
+    public String getFieldName() {
+        return "title";
+    }
+
+    /**
+     * Returns the rejected value of the affected field.
+     *
+     * <p>In this case, the rejected value is the {@code title}.
+     *
+     * @return the rejected value of the affected field
+     */
+    public String getFieldValue() {
+        return prizeTitle;
+    }
+
+    @Override
+    public void populate(
+        final Environment environment,
+        final Map<String, Object> attributes)
+    {
+        attributes.put("field", getFieldName());
+        attributes.put("rejectedValue", getFieldValue());
+    }
+}
+

--- a/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/domain/prizes/UnableToEditLockedPrizeDetailException.java
+++ b/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/domain/prizes/UnableToEditLockedPrizeDetailException.java
@@ -1,0 +1,56 @@
+package io.davorpatech.apps.musicalsurveyor.domain.prizes;
+
+
+import io.davorpatech.fwk.exception.PreconditionalException;
+import io.davorpatech.fwk.model.ErrorDomain;
+import io.davorpatech.fwk.model.Identifiable;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+/**
+ * Exception raised when we try to edit a prize detail, but the prize is locked
+ * due to some business rule, such as the prize being already awarded.
+ *
+ * The prize ID and the reason why the prize is locked are provided.
+ */
+@ResponseStatus(HttpStatus.PRECONDITION_FAILED)
+public class UnableToEditLockedPrizeDetailException extends PreconditionalException // NOSONAR
+    implements Identifiable<Serializable>, ErrorDomain // NOSONAR
+{
+    @Serial
+    private static final long serialVersionUID = 2065792092394629439L;
+
+    private final Serializable id;
+
+    /**
+     * Construct a {@code UnableToEditLockedPrizeDetailException} with the specified arguments.
+     *
+     * @param id     the prize ID we tried to edit
+     * @param reason the reason why the prize is locked
+     */
+    public UnableToEditLockedPrizeDetailException(Serializable id, String reason)
+    {
+        super(String.format(
+            "Unable to edit the prize detail identified by `%s` because it is locked: %s.",
+            id, reason));
+        this.id = id;
+    }
+
+    @Override
+    public String getDomain() {
+        return PrizeConstants.DOMAIN_NAME;
+    }
+
+/**
+     * Returns the prize ID where the business rule has been violated.
+     *
+     * @return the identifier of the prize
+     */
+    @Override
+    public Serializable getId() {
+        return id;
+    }
+}

--- a/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/persistence/dao/RafflePrizeRepository.java
+++ b/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/persistence/dao/RafflePrizeRepository.java
@@ -52,4 +52,31 @@ public interface RafflePrizeRepository extends JpaRepository<RafflePrize, Raffle
      */
     @Query("SELECT COUNT(rp) FROM #{#entityName} rp WHERE rp.prize.id = ?1")
     long countByPrize(Long prizeId);
+
+    /**
+     * Returns whether there are any prizes associated with the given {@code prizeId}
+     * that have been awarded to some winner.
+     *
+     * @param prizeId the prize ID to check, never {@code null}
+     * @return {@code true} if there are any prizes associated with the given
+     *         {@code prizeId} that have been awarded to a winner, {@code false} otherwise
+     */
+    default boolean existsAwardedTicketsByPrize(Long prizeId) {
+        return countAwardedTicketsByPrize(prizeId) > 0;
+    }
+
+    /**
+     * Returns the number of prizes associated with the given {@code prizeId}
+     * that have been awarded to some winner.
+     *
+     * <p>Zero represents that there are no prizes associated with the given
+     * {@code prizeId} that have been awarded to a winner, so it's safe to edit
+     * the prize details (e.g. change its title, description, or monetary value).
+     *
+     * @param prizeId the prize ID to check, never {@code null}
+     * @return the number of awarded prizes associated with the given {@code prizeId},
+     *         always greater than or equal to 0
+     */
+    @Query("SELECT COUNT(rp) FROM #{#entityName} rp WHERE rp.prize.id = ?1 AND rp.winnerTicket IS NOT NULL")
+    long countAwardedTicketsByPrize(Long prizeId);
 }

--- a/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/persistence/dao/RafflePrizeRepository.java
+++ b/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/persistence/dao/RafflePrizeRepository.java
@@ -3,6 +3,7 @@ package io.davorpatech.apps.musicalsurveyor.persistence.dao;
 import io.davorpatech.apps.musicalsurveyor.persistence.model.RafflePrize;
 import io.davorpatech.apps.musicalsurveyor.persistence.model.RafflePrizeId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,5 +29,27 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public interface RafflePrizeRepository extends JpaRepository<RafflePrize, RafflePrizeId>
 {
+    /**
+     * Returns whether there are any raffle prizes associated with the given {@code prizeId}.
+     *
+     * @param prizeId the prize ID to check, never {@code null}
+     * @return {@code true} if there are any raffle prizes associated with the given
+     *         {@code prizeId}, {@code false} otherwise
+     */
+    default boolean existsByPrize(Long prizeId) {
+        return countByPrize(prizeId) > 0;
+    }
 
+    /**
+     * Returns the number of raffle prizes associated with the given {@code prizeId}.
+     *
+     * <p>Zero represents that there are no raffle prizes associated with the given
+     * {@code prizeId}, so it's safe to delete the prize.
+     *
+     * @param prizeId the prize ID to check, never {@code null}
+     * @return the number of raffle prizes associated with the given {@code prizeId},
+     *         never {@code null}, always greater than or equal to 0
+     */
+    @Query("SELECT COUNT(rp) FROM #{#entityName} rp WHERE rp.prize.id = ?1")
+    long countByPrize(Long prizeId);
 }

--- a/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/services/prizes/PrizeServiceImpl.java
+++ b/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/services/prizes/PrizeServiceImpl.java
@@ -107,6 +107,13 @@ public class PrizeServiceImpl extends JpaBasedDataService<
     @Override
     protected void populateEntityToUpdate(
             @NonNull Prize entity, @NonNull UpdatePrizeInput input) {
+        Long prizeId = entity.getId();
+        if (rafflePrizeRepository.existsAwardedTicketsByPrize(prizeId)) {
+            // business rule: a prize that has been awarded to some winner cannot be edited
+            throw new UnableToEditLockedPrizeDetailException(prizeId,
+                "Already awarded to some winner");
+        }
+        // populate the entity with the input data
         entity.setTitle(input.getTitle());
         entity.setDescription(input.getDescription());
         entity.setMonetaryValue(input.getMonetaryValue());

--- a/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/web/controller/PrizeController.java
+++ b/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/web/controller/PrizeController.java
@@ -219,6 +219,10 @@ public class PrizeController // NOSONAR
         responseCode = "409",
         description = "Prize already exists",
         content = @Content)
+    @ApiResponse(
+        responseCode = "412",
+        description = "Prize cannot be updated because it is used by other resources",
+        content = @Content)
     @PutMapping("/{id}")
     ResponseEntity<PrizeDTO> update(
         @Parameter(description = "The identifier of the prize to be updated", example = "1")

--- a/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/web/controller/PrizeController.java
+++ b/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/web/controller/PrizeController.java
@@ -165,6 +165,10 @@ public class PrizeController // NOSONAR
         responseCode = "400",
         description = "Request parameters are invalid",
         content = @Content)
+    @ApiResponse(
+        responseCode = "409",
+        description = "Prize already exists",
+        content = @Content)
     @PostMapping
     ResponseEntity<PrizeDTO> create(
         @RequestBody @Validated CreatePrizeRequest request)
@@ -211,6 +215,10 @@ public class PrizeController // NOSONAR
         responseCode = "404",
         description = "Prize not found",
         content = @Content)
+    @ApiResponse(
+        responseCode = "409",
+        description = "Prize already exists",
+        content = @Content)
     @PutMapping("/{id}")
     ResponseEntity<PrizeDTO> update(
         @Parameter(description = "The identifier of the prize to be updated", example = "1")
@@ -250,6 +258,10 @@ public class PrizeController // NOSONAR
     @ApiResponse(
         responseCode = "404",
         description = "Prize not found",
+        content = @Content)
+    @ApiResponse(
+        responseCode = "409",
+        description = "Prize is used by other resources",
         content = @Content)
     @DeleteMapping("/{id}")
     ResponseEntity<Void> deleteById(


### PR DESCRIPTION
Se implementa las reglas de negocio por la cual los `Prize`:

- [x] al crear o editar no pueden tener titulos repetidos.
- [x] no se podrá eliminar premios que tengan asociados algun sorteo.
- [x] se limita la edición de premios que estén asociados a algún boleto ganador.
- [x] Test using Swagger interface provista por los controladores REST

Depende de #6 para poder ser probada mediante los controller pertinentes