### PR TITLE
Implement `Survey` manual closing operation

### DIFF
--- a/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/domain/surveys/UnableToCloseSurveyException.java
+++ b/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/domain/surveys/UnableToCloseSurveyException.java
@@ -1,0 +1,54 @@
+package io.davorpatech.apps.musicalsurveyor.domain.surveys;
+
+
+import io.davorpatech.fwk.exception.PreconditionalException;
+import io.davorpatech.fwk.model.ErrorDomain;
+import io.davorpatech.fwk.model.Identifiable;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+/**
+ * Exception raised when we try to close a survey but it has an internal state that
+ * prevents it from being closed.
+ *
+ * The survey ID and the reason why the prize is locked are provided.
+ */
+@ResponseStatus(HttpStatus.PRECONDITION_FAILED)
+public class UnableToCloseSurveyException extends PreconditionalException // NOSONAR
+    implements Identifiable<Serializable>, ErrorDomain // NOSONAR
+{
+    @Serial
+    private static final long serialVersionUID = 4299456951564569984L;
+
+    private final Serializable id;
+
+    /**
+     * Construct a {@code UnableToCloseSurveyException} with the specified arguments.
+     *
+     * @param id     the survey ID we tried to edit
+     * @param reason the reason why cannot be closed
+     */
+    public UnableToCloseSurveyException(Serializable id, String reason)
+    {
+        super(String.format("Unable to close survey identified by `%s`: %s", id, reason));
+        this.id = id;
+    }
+
+    @Override
+    public String getDomain() {
+        return SurveyConstants.DOMAIN_NAME;
+    }
+
+    /**
+     * Returns the survey ID where the business rule has been violated.
+     *
+     * @return the identifier of the survey
+     */
+    @Override
+    public Serializable getId() {
+        return id;
+    }
+}

--- a/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/persistence/dao/SurveyParticipationRepository.java
+++ b/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/persistence/dao/SurveyParticipationRepository.java
@@ -30,50 +30,83 @@ import org.springframework.transaction.annotation.Transactional;
 public interface SurveyParticipationRepository extends JpaRepository<SurveyParticipation, SurveyParticipationId>
 {
     /**
-     * Returns whether there are any survey participations associated with the given {@code participantId}.
+     * Returns whether there are any survey participations associated with the given
+     * {@code participantId}.
      *
      * @param participantId the participant ID to check, never {@code null}
-     * @return {@code true} if there are any survey participations associated with the given
-     *         {@code participantId}, {@code false} otherwise
+     * @return {@code true} if there are any survey participations associated with the
+     *         given {@code participantId}, {@code false} otherwise
      */
     default boolean existsByParticipant(Long participantId) {
         return countByParticipant(participantId) > 0L;
     }
 
     /**
-     * Returns the number of survey participations associated with the given {@code participantId}.
+     * Returns the number of survey participations associated with the given
+     * {@code participantId}.
      *
-     * <p>Zero represents that there are no survey participations associated with the given
-     * {@code participantId}, so it's safe to delete the participant.
+     * <p>Zero represents that there are no survey participations associated with the
+     * given {@code participantId}, so it's safe to delete the participant.
      *
      * @param participantId the participant ID to check, never {@code null}
-     * @return the number of survey participations associated with the given {@code participantId},
-     *         never {@code null}, always greater than or equal to 0
+     * @return the number of survey participations associated with the given
+     *         {@code participantId}, never {@code null}, always greater than or equal
+     *         to 0
      */
     @Query("SELECT COUNT(sp) FROM #{#entityName} sp WHERE sp.participant.id = ?1")
     long countByParticipant(Long participantId);
 
     /**
-     * Returns whether there are any survey participations associated with the given {@code surveyId}.
+     * Returns whether there are any survey participations associated with the given
+     * {@code surveyId}.
      *
      * @param surveyId the survey ID to check, never {@code null}
-     * @return {@code true} if there are any survey participations associated with the given
-     *         {@code surveyId}, {@code false} otherwise
+     * @return {@code true} if there are any survey participations associated with the
+     *         given {@code surveyId}, {@code false} otherwise
      */
     default boolean existsBySurvey(Long surveyId) {
         return countBySurvey(surveyId) > 0L;
     }
 
     /**
-     * Returns the number of survey participations associated with the given {@code surveyId}.
+     * Returns the number of survey participations associated with the given
+     * {@code surveyId}.
      *
-     * <p>Zero represents that there are no survey participations associated with the given
-     * {@code surveyId}, so it's safe to delete the survey.
+     * <p>Zero represents that there are no survey participations associated with the
+     * given {@code surveyId}, so it's safe to delete the survey.
      *
      * @param surveyId the survey ID to check, never {@code null}
-     * @return the number of survey participations associated with the given {@code surveyId},
-     *         never {@code null}, always greater than or equal to 0
+     * @return the number of survey participations associated with the given
+     *         {@code surveyId}, never {@code null}, always greater than or equal to 0
      */
     @Query("SELECT COUNT(sp) FROM #{#entityName} sp WHERE sp.survey.id = ?1")
     long countBySurvey(Long surveyId);
+
+    /**
+     * Returns whether there are some participants that have completed the survey
+     * associated with the given {@code surveyId}.
+     *
+     * @param surveyId the survey ID to check, never {@code null}
+     * @return {@code true} if there are some participants that have completed the
+     *         survey associated with the given {@code surveyId}, {@code false}
+     *         otherwise
+     */
+    default boolean existsByRespondedSurvey(Long surveyId) {
+        return countByRespondedSurvey(surveyId) > 0L;
+    }
+
+    /**
+     * Returns the number of participants that have completed the survey associated
+     * with the given {@code surveyId}.
+     *
+     * <p>Zero represents that there are no participants that have completed the
+     * survey associated with the given {@code surveyId}
+     *
+     * @param surveyId the survey ID to check, never {@code null}
+     * @return the number of participants that have completed the survey associated
+     *         with the given {@code surveyId}, never {@code null}, always greater
+     *         than or equal to 0
+     */
+    @Query("SELECT COUNT(sp) FROM #{#entityName} sp WHERE sp.survey.id = ?1 AND sp.responses IS NOT EMPTY")
+    long countByRespondedSurvey(Long surveyId);
 }

--- a/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/services/surveys/SurveyService.java
+++ b/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/services/surveys/SurveyService.java
@@ -6,6 +6,7 @@ import io.davorpatech.apps.musicalsurveyor.domain.surveys.SurveyDTO;
 import io.davorpatech.apps.musicalsurveyor.domain.surveys.UpdateSurveyInput;
 import io.davorpatech.apps.musicalsurveyor.persistence.model.Survey;
 import io.davorpatech.fwk.service.data.DataService;
+import org.springframework.lang.NonNull;
 
 /**
  * Service for managing {@link Survey} data domain.
@@ -15,4 +16,19 @@ public interface SurveyService extends DataService<
         FindSurveysInput, CreateSurveyInput, UpdateSurveyInput> // NOSONAR
 {
 
+    /**
+     * Closes the survey with the given {@code id}.
+     *
+     * <p>Closed surveys are frozen resources that cannot be updated or deleted.
+     *
+     * <p>Surveys can be manually closed only if its end date has been reached
+     * and there are some participant who have completed the survey sending their
+     * favourite songs. Closing surveys already closed has no effect.
+     *
+     * <p>Only surveys in this final state are eligible for raffles or prize draws.
+     *
+     * @param id the id of the survey to close
+     * @return the closed survey
+     */
+    @NonNull SurveyDTO close(@NonNull Long id);
 }

--- a/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/web/controller/SurveyController.java
+++ b/musical-surveyor-app/src/main/java/io/davorpatech/apps/musicalsurveyor/web/controller/SurveyController.java
@@ -273,4 +273,49 @@ public class SurveyController // NOSONAR
         surveyService.deleteById(id);
         return ResponseEntity.noContent().build();
     }
+
+    /**
+     * Close the {@code Survey} resource with the given ID.
+     *
+     * @param id the identifier of the survey to be manually closed
+     */
+    @Operation(
+        summary = "Closes a survey by ID",
+        description = """
+            Closes a survey by its identifier.
+            
+            The identifier is a numeric value.
+
+            Closed surveys are frozen resources that cannot be updated or deleted.
+            
+            Surveys can be manually closed only if its end date has been reached and there are
+            some participant who have completed the survey sending their favourite songs.
+            Closing surveys already closed has no effect.
+            
+            Only surveys in this final state are eligible for raffles or prize draws.""",
+        tags = { "survey" }
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "Successful operation")
+    @ApiResponse(
+        responseCode = "400",
+        description = "Request parameters are invalid",
+        content = @Content)
+    @ApiResponse(
+        responseCode = "404",
+        description = "Survey not found",
+        content = @Content)
+    @ApiResponse(
+        responseCode = "412",
+        description = "Survey cannot be closed due to business rules",
+        content = @Content)
+    @PostMapping("/{id}/close")
+    ResponseEntity<SurveyDTO> close(
+        @Parameter(description = "The identifier of the survey to be closed", example = "1")
+        @PathVariable("id") Long id)
+    {
+        SurveyDTO dto = surveyService.close(id);
+        return ResponseEntity.ok(dto);
+    }
 }


### PR DESCRIPTION
Surveys can be manually closed only if its end date has been reached and there are some participant who have completed the survey sending their favourite songs.

Closing surveys already closed has no effect.

Only surveys in this final state are eligible for raffles or prize draws.